### PR TITLE
made external reference to vclock code, added getter for current Vclock

### DIFF
--- a/govec/govec.go
+++ b/govec/govec.go
@@ -3,7 +3,7 @@ package govec
 import "fmt"
 import "encoding/gob"
 import "bytes"
-import "./vclock"
+import "github.com/arcaneiceman/GoVector/govec/vclock"
 import "os"
 import "strings"
 import "strconv"
@@ -118,6 +118,11 @@ func (d *Data) PrintDataString() {
 	fmt.Println(s)
 	s = string(d.programdata[:])
 	fmt.Println("-----DATA END -----")
+}
+
+// TODO Pull request for this function
+func (gv *GoLog) GetCurrentVC() []byte {
+	return gv.currentVC
 }
 
 func (gv *GoLog) LogThis(Message string, ProcessID string, VCString string) bool {


### PR DESCRIPTION
Hi Wally,

I have been using GoVec for the implementation of Dinv (Ivan distributed invariant detector). We use govec to keep track of vector clocks so we can log them on the fly. We can't log them ourselves without an accessors though. It would be great if you could add this in.

cheers,
-Stewart Grant