### PR TITLE
Create log path when initializing if it does not exist (and a bit on format print)

### DIFF
--- a/govec/govec.go
+++ b/govec/govec.go
@@ -1,17 +1,19 @@
 package govec
 
-import "fmt"
-import "encoding/gob"
-import "bytes"
 import (
+	"bufio"
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	"github.com/arcaneiceman/GoVector/govec/vclock"
 	"github.com/hashicorp/go-msgpack/codec"
 )
-import "os"
-import "strings"
-import "strconv"
-import "io"
-import "bufio"
 
 /*
    - All licences like other licenses ...
@@ -461,6 +463,12 @@ func Initialize(processid string, logfilename string) *GoLog {
 		fmt.Println(logname, "exists! ... Deleting ")
 		os.Remove(logname)
 	}
+
+	// Create directory path to log if it doesn't exist.
+	if err := os.MkdirAll(filepath.Dir(logname), 0750); err != nil {
+		panic(err)
+	}
+
 	//Creating new Log
 	file, err := os.Create(logname)
 	if err != nil {


### PR DESCRIPTION
@arcaneiceman 

Hey Wali,

Thomas here -- this is a minor change to avoid panics when the logname contains a path with non-existent dirs. Mostly because I wanted logs to go alongside some other system logs in our servers' /tmp dirs rather than cwd.

Also, here's the little format print thing we had. I can attempt to implement it in a more permanent way if you think it'd be of any use.

https://github.com/tyangliu/GoVector/commit/cc3299b27fbbdee5f31ac5ba5bb36738997420ad

and let me know too if there are (more important) features needing help of course!